### PR TITLE
Update compile and testCompile methods in build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,8 +24,8 @@ android {
 }
 
 dependencies {
-  compile fileTree(dir: 'libs', include: ['*.jar'])
-  testCompile 'junit:junit:4.12'
-  compile 'com.android.support:appcompat-v7:23.2.1'
-  compile 'com.facebook.react:react-native:+'
+  implementation fileTree(dir: 'libs', include: ['*.jar'])
+  testImplementation 'junit:junit:4.12'
+  implementation 'com.android.support:appcompat-v7:23.2.1'
+  implementation 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
Update "compile" and "testCompile" methods in "build.gradle", they are deprecated.